### PR TITLE
feat(allen): add profiles

### DIFF
--- a/profiles/allen.html
+++ b/profiles/allen.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PHT</title>
+</head>
+<body>
+    <h1>Allen</h1>
+    <p>Allen is a software engineer with a passion for open-source projects and community building. He has over 10 years of experience in the tech industry and enjoys mentoring junior developers.</p>
+    <p>In his free time, Allen likes to hike, read science fiction novels, and experiment with new programming languages.</p>
+    <p>Contact Allen at: <a href="mailto:allen@example.com">allen@example.com</a></p>
+    <p>Follow Allen on Twitter: <a href="https://twitter.com/allen" target="_blank" rel="noopener">@allen</a></p>
+    <p>Connect with Allen on LinkedIn: <a href="https://www.linkedin.com/in/allen" target="_blank" rel="noopener">LinkedIn Profile</a></p>
+    <p>Check out Allen's GitHub: <a href="https://github.com/allen" target="_blank" rel="noopener">GitHub Profile</a></p>
+    <p>Visit Allen's personal blog: <a href="https://allenblog.com" target="_blank" rel="noopener">allenblog.com</a></p>
+    <p>Allen's favorite quote: "Code is like humor. When you have to explain it, it’s bad." - Cory House</p>
+    
+</body>
+</html>x


### PR DESCRIPTION
This pull request adds a new profile page for Allen. The page provides an introduction, contact information, and links to Allen's social media and personal projects.

New profile page:

* Added a new HTML file `profiles/allen.html` containing Allen's bio, contact email, social media links (Twitter, LinkedIn, GitHub), personal blog, and a favorite quote.